### PR TITLE
docker-compose: mssql.configurator

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -30,7 +30,7 @@ services:
       DB_NAME: animales
     command: >
       bash -c '
-      /opt/mssql-tools18/bin/sqlcmd -S mssql -U sa -P $$SA_PASSWORD -C -Q "CREATE DATABASE IF NOT EXISTS $${DB_NAME};"
+      /opt/mssql-tools18/bin/sqlcmd -S mssql -U sa -P $${SA_PASSWORD} -C -Q "IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = \"$${DB_NAME}\") BEGIN CREATE DATABASE $${DB_NAME} END " || exit
       '
   api:
     image: sqlserver

--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,7 @@ services:
       SA_PASSWORD: P4ssw0rd!
       TZ: America/Montevideo
     healthcheck:
-      test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $$SA_PASSWORD -Q 'SELECT 1' || exit 1"]
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P $${SA_PASSWORD} -C -Q 'SELECT 1' || exit 1"]
       interval: 10s
       retries: 10
       start_period: 10s
@@ -30,7 +30,7 @@ services:
       DB_NAME: animales
     command: >
       bash -c '
-      /opt/mssql-tools/bin/sqlcmd -S mssql -U sa -P $$SA_PASSWORD -Q "CREATE DATABASE IF NOT EXISTS $${DB_NAME};"
+      /opt/mssql-tools18/bin/sqlcmd -S mssql -U sa -P $$SA_PASSWORD -C -Q "CREATE DATABASE IF NOT EXISTS $${DB_NAME};"
       '
   api:
     image: sqlserver


### PR DESCRIPTION
Se corrigieron los errores en el  `compose.yml` para que cree la base de datos de forma automática al iniciar el servicio si esta no existe.